### PR TITLE
Make the values of 'almostBlack' and 'darkGrey' represent their names a little better

### DIFF
--- a/colors/hemisu.vim
+++ b/colors/hemisu.vim
@@ -22,11 +22,11 @@ let g:colors_name="hemisu"
 let s:black=           { "gui": "#000000", "cterm": "16"  }
 let s:white=           { "gui": "#FFFFFF", "cterm": "231" }
 let s:almostWhite=     { "gui": "#EEEEEE", "cterm": "255" }
-let s:almostBlack=     { "gui": "#111111", "cterm": "235" }
+let s:almostBlack=     { "gui": "#111111", "cterm": "233" }
 let s:middleDarkGrey=  { "gui": "#777777", "cterm": "238" }
 let s:middleLightGrey= { "gui": "#999999", "cterm": "246" }
 let s:lightGrey=       { "gui": "#BBBBBB", "cterm": "249" }
-let s:darkGrey=        { "gui": "#444444", "cterm": "233" }
+let s:darkGrey=        { "gui": "#444444", "cterm": "235" }
 
 let s:darkPink=        { "gui": "#63001C", "cterm": "88"  }
 let s:middleDarkPink=  { "gui": "#FF0055", "cterm": "197" }


### PR DESCRIPTION
This makes line numbers a lot clearer without affecting much else in the color scheme.
