### PR TITLE
Check the value of the global background option.

### DIFF
--- a/colors/hemisu.vim
+++ b/colors/hemisu.vim
@@ -47,7 +47,7 @@ let s:darkTan=         { "gui": "#503D15", "cterm": "52"  }
 let s:lightTan=        { "gui": "#ECE1C8", "cterm": "230" }
 
 " Assign to semantic categories based on background color
-if &background=="dark"
+if &g:background=="dark"
 	" Dark theme
 	let s:bg=s:black
 	let s:norm=s:almostWhite


### PR DESCRIPTION
Before, this only took into account the 'local' setting, which didn't work if 'background' was set in vimrc. Make sure that 'background' is set to the desired value _before_ setting the color scheme to hemisu in your vimrc.
