### PR TITLE
Add info on t_Co in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ add the following to your .vimrc:
 
 	syntax on
 	colorscheme hemisu
+	
+Depending on your system you may need to enable 256 color mode using the command set t_Co=256. This can also be added to your .vimrc
 
 Change Log
 ----------


### PR DESCRIPTION
Added info on setting t_Co which is required for hemisu to work on some terminals.
Without it the new colours were not showing up on Bash (Debian)
